### PR TITLE
Fix regex escape strings in tests

### DIFF
--- a/tensorflow/python/kernel_tests/control_flow/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow/control_flow_ops_py_test.py
@@ -1143,7 +1143,7 @@ class ControlFlowTest(test.TestCase, parameterized.TestCase):
           errors_impl.InvalidArgumentError,
           r"Connecting to invalid output 1 of source node cond which has 1 "
           r"outputs. Try using "
-          "tf.compat.v1.experimental.output_all_intermediates\(True\)."):
+          r"tf.compat.v1.experimental.output_all_intermediates(True)."):
         self.evaluate(grad)
 
   @test_util.run_deprecated_v1

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3864,14 +3864,14 @@ class MutableHashTableOpTest(test.TestCase):
 
     with self.assertRaisesRegex(
         (ValueError, errors_impl.InvalidArgumentError),
-        "Expected shape \[2\] or \[2,2,2\] for default value, got \[4,2]"):
+        r"Expected shape \[2\] or \[2,2,2\] for default value, got \[4,2]"):
       self.evaluate(table.lookup(input_string, invalid_default_val))
 
     invalid_default_val = constant_op.constant([[[-2, -3], [-4, -5]]],
                                                dtypes.int64)
     with self.assertRaisesRegex(
         (ValueError, errors_impl.InvalidArgumentError),
-        "Expected shape \[2\] or \[2,2,2\] for default value, got \[1,2,2\]"):
+        r"Expected shape \[2\] or \[2,2,2\] for default value, got \[1,2,2\]"):
       self.evaluate(table.lookup(input_string, invalid_default_val))
 
   def testMutableHashTableFindHighRankScalarWithDynamicDefaultValue(

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_to_dense_op_py_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_to_dense_op_py_test.py
@@ -124,7 +124,7 @@ class SparseToDenseTest(test.TestCase, parameterized.TestCase):
     # the reference error messages between GPUs and CPUs.
     error_msg = (r"out of bounds" if test_util.is_gpu_available() else
                  r"indices\[1\] = \[10\] is out of bounds: need 0 <= "
-                 "index < \[5\]")
+                 r"index < \[5\]")
     with self.assertRaisesRegex((ValueError, errors.InvalidArgumentError),
                                 error_msg):
       self.evaluate(

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_d9m_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_d9m_test.py
@@ -160,7 +160,7 @@ class SparseXentOpDeterministicTest(
     deterministic implementation, tf.gather throws an exception instead.
     """
     self._testInvalidLabelCPU(
-        expected_regex="indices\[0\] = 4 is not in \[0, 4\)")
+        expected_regex=r"indices\[0\] = 4 is not in \[0, 4\)")
 
   def testLabelsPlaceholderScalar(self):
     """Test exception-throwing for non-statically-shaped, zero-rank labels.
@@ -171,7 +171,7 @@ class SparseXentOpDeterministicTest(
     throws an error.
     """
     self._testLabelsPlaceholderScalar(
-        expected_error_message="Expected batch_dims in the range \[0, 0\], " +
+        expected_error_message=r"Expected batch_dims in the range \[0, 0\], " +
         "but got 1")
 
   def testScalarHandling(self):
@@ -183,7 +183,7 @@ class SparseXentOpDeterministicTest(
     throws an error.
     """
     self._testScalarHandling(
-        expected_regex="Expected batch_dims in the range \[0, 0\], but got 1.*")
+        expected_regex=r"Expected batch_dims in the range \[0, 0\], but got 1.*")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use raw strings for regex to avoid SyntaxWarning in control_flow_ops_py_test
- update lookup_ops_test expected error messages to raw strings
- fix sparse_to_dense_op_py_test regex string
- correct sparse_xent_op_d9m_test regex patterns

## Testing
- `python3 -m py_compile tensorflow/python/kernel_tests/control_flow/control_flow_ops_py_test.py tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py tensorflow/python/kernel_tests/sparse_ops/sparse_to_dense_op_py_test.py tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_d9m_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ecd72ec083338e0bcd21ce255f8f