### PR TITLE
Fix decoding in pip smoke test

### DIFF
--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -175,6 +175,8 @@ def main():
                     (" + ".join(PYTHON_TARGETS), missing_dependency))
       affected_tests = subprocess.check_output(
           ["bazel", "cquery", "--experimental_cc_shared_library", rdep_query])
+      if isinstance(affected_tests, bytes):
+        affected_tests = affected_tests.decode("utf-8")
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))
 


### PR DESCRIPTION
## Summary
- avoid bytes/string type error when listing affected tests

## Testing
- `python -m py_compile tensorflow/tools/pip_package/pip_smoke_test.py`
- `python tensorflow/tools/pip_package/pip_smoke_test.py --help` *(fails: unable to download bazel)*

------
https://chatgpt.com/codex/tasks/task_e_684c13ce0f3483338ae7a9a5a09c9fdd